### PR TITLE
Add ctypes-based callbacks.

### DIFF
--- a/cubature/get_ptr.c
+++ b/cubature/get_ptr.c
@@ -1,0 +1,15 @@
+#include "Python.h"
+
+// First part of PyCFuncPtrObject in Modules/_ctypes/ctypes.h
+typedef struct {
+    PyObject_HEAD char *b_ptr;
+} cfuncptr_object;
+
+
+// function pointer - any signature will work
+typedef int (*_func_ptr)(double);
+
+_func_ptr get_ctypes_function_pointer(PyObject *obj)
+{
+    return (*((void **) (((cfuncptr_object *)(obj))->b_ptr)));
+}

--- a/cubature/get_ptr.h
+++ b/cubature/get_ptr.h
@@ -1,0 +1,4 @@
+#include "Python.h"
+
+// Get the raw function pointer from a ctypes PyCFuncPtrObject (CFuncPtr)
+void* get_ctypes_function_pointer(PyObject *obj);

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ try:
             sources = [
                 'cubature/_cubature.pyx',
                 'cubature/cpackage/hcubature.c',
-                'cubature/cpackage/pcubature.c'],),
+                'cubature/cpackage/pcubature.c',
+                'cubature/get_ptr.c'],),
         Extension('cubature._test_integrands',
             sources = ['cubature/_test_integrands.pyx']),
     ]


### PR DESCRIPTION
Following scipy.integrate to allow faster callbacks.
Primarily intended for symbolic integrands from Sympy JIT (see the code in branch 'callback'  here: https://github.com/markdewing/sympy/tree/callback

Some timing results for a simple 3-d integral

nquad w/python callback, time = 0.122 s
nquad w/jit callback, time = 0.048 s, speedup = 2.55
cubature w/python callback, time = 0.864 s
cubature w/jit callback, time = 0.005 s, speedup = 166.11

**Example code**
```python
from` __future__ import print_function

import sympy.printing.llvmjitcode as jit
from sympy import exp
from sympy.abc import x,y,z
from scipy.integrate import nquad
import math
from cubature import cubature
from timeit import timeit


# Sympy expression
e = exp(-2.0*(x*x + y*y + z*z))

# Python version (for nquad)
def f(x,y,z):
    return math.exp(-2.0*(x*x + y*y + z*z))

# Python version (for cubature)
def cf(array):
    x = array[0]
    y = array[1]
    z = array[2]
    return math.exp(-2.0*(x*x + y*y + z*z))

ndim = 3
lim = [0.0, 10.0]
lims = [lim]*ndim
lim_min = [lim[0]]*ndim
lim_max = [lim[1]]*ndim

# Scipy.integrate.nquad

# Python callback
def run_nquad():
    nquad(f, lims)
nquad_time = timeit(stmt=run_nquad, number=1)
print('nquad w/python callback, time = %.3f s'%nquad_time)

# JIT compiled callback
e_scipy = jit.llvm_callable([x,y,z], e, callback_type='scipy.integrate')
def run_nquad_jit():
    nquad(e_scipy, lims)
nquad_time_jit = timeit(stmt=run_nquad_jit, number=1)
print('nquad w/jit callback, time = %.3f s, speedup = %.2f'%(nquad_time_jit,nquad_time/nquad_time_jit))


# Cubature

# Python callback
def run_cubature():
    cubature(cf, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time = timeit(stmt=run_cubature, number=1)
print('cubature w/python callback, time = %.3f s'%cubature_time)


# JIT compiled callback
e_cub = jit.llvm_callable([x,y,z], e, callback_type='cubature')
def run_cubature_jit():
    cubature(e_cub, ndim=3, fdim=1, xmin=lim_min, xmax=lim_max)
cubature_time_jit = timeit(stmt=run_cubature_jit, number=1)
print('cubature w/jit callback, time = %.3f s, speedup = %.2f'%(cubature_time_jit,cubature_time/cubature_time_jit))
```

