### PR TITLE
Fix avoid evaluation at xmin

### DIFF
--- a/cubature/cubature.py
+++ b/cubature/cubature.py
@@ -215,7 +215,7 @@ def cubature(func, ndim, fdim, xmin, xmax, args=tuple(), kwargs=dict(),
     # checking fdim
     if not use_raw_callback:
         if not vectorized:
-            out = func(np.ones(ndim)*xmin, *args, **kwargs)
+            out = func(np.ones(ndim)*(xmin+xmax)/2, *args, **kwargs)
             try:
                 if isinstance(out, float) or isinstance(out, int):
                     out = np.array([out])
@@ -224,7 +224,7 @@ def cubature(func, ndim, fdim, xmin, xmax, args=tuple(), kwargs=dict(),
                 raise ValueError(
                     'Length of func ouptut vector is different than fdim')
         else:
-            out = func(np.ones((7, ndim))*xmin, *args, **kwargs)
+            out = func(np.ones((7, ndim))*(xmin+xmax)/2, *args, **kwargs)
             if fdim > 1:
                 try:
                     assert out.shape[0] == 7


### PR DESCRIPTION
For the moment I think the issue was the the function was being checked at `xmin`. Now it is evaluated at `(xmin+xmax)/2`.  I tested this modification in single and multivariable integration.