### PR TITLE
Add tests for cubature wrapper, +3.13, -3.7

### DIFF
--- a/.github/workflows/pytest_and_coverage.yml
+++ b/.github/workflows/pytest_and_coverage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.runs-on }}
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4
@@ -19,13 +19,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      if: matrix.runs-on == 'windows-latest' || (matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12') || (matrix.runs-on == 'macos-latest')
+      if: matrix.runs-on == 'windows-latest' || (matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.13') || (matrix.runs-on == 'macos-latest')
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade setuptools wheel twine
         python3 -m pip install -r requirements.txt
     - name: Upload source code
-      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.13'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
@@ -44,17 +44,17 @@ jobs:
       run: |
         python3 -m twine upload dist/*.whl
     - name: Build Linux Python wheels, install cibuildwheel
-      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.13'
       run: |
         python3 -m pip install cibuildwheel==2.17.0
     - name: Build Linux Python wheels
-      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.13'
       env:
-        CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
       run: |
         python3 -m cibuildwheel --output-dir dist
     - name: Publish Linux Python wheels
-      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.13'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 numpy
 cython
-coveralls
+coverage
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ Intended Audience :: Developers
 Intended Audience :: Education
 Topic :: Scientific/Engineering :: Mathematics
 License :: OSI Approved :: BSD License
-Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
+Programming Language :: Python :: 3.13
 Operating System :: Microsoft :: Windows
 Operating System :: Unix
 Operating System :: POSIX :: BSD

--- a/tests/test_cubature_wrapper.py
+++ b/tests/test_cubature_wrapper.py
@@ -1,0 +1,63 @@
+import ctypes
+import numpy as np
+import pytest
+
+import importlib
+cubature_module = importlib.import_module('cubature.cubature')
+from cubature import cubature as cub
+
+
+def test_invalid_xmin_length():
+    def f(x):
+        return np.array([0.0])
+    with pytest.raises(AssertionError):
+        cub(f, ndim=2, fdim=1, xmin=[0], xmax=[1, 1])
+
+
+def test_invalid_vectorized_output_shape():
+    def f(x):
+        # return wrong shape: not (7, fdim)
+        return np.ones((5, 2))
+    with pytest.raises(ValueError, match=r"shape=\(:, fdim\)"):
+        cub(f, ndim=1, fdim=2, xmin=[0], xmax=[1], vectorized=True)
+
+
+def test_invalid_scalar_vectorized_output():
+    def f(x):
+        # return 2D array but fdim=1
+        return np.ones((7, 1, 1))
+    with pytest.raises(ValueError, match=r"valid array"):
+        cub(f, ndim=1, fdim=1, xmin=[0], xmax=[1], vectorized=True)
+
+
+def test_invalid_adaptive_option():
+    def f(x):
+        return np.array([0.0])
+    with pytest.raises(ValueError, match="unknown combination"):
+        cub(f, ndim=1, fdim=1, xmin=[0], xmax=[1], adaptive='z')
+
+
+def test_raw_callback(monkeypatch):
+    called = {}
+
+    def fake_raw(func, ndim, fdim, xmin, xmax, method, abserr, relerr, norm, maxEval, args=(), kwargs=None):
+        called['raw'] = True
+        return np.array([1.0]), np.array([0.0])
+
+    def fake_standard(*a, **k):
+        called['standard'] = True
+        return np.array([1.0]), np.array([0.0])
+
+    monkeypatch.setattr(cubature_module, '_cython_cubature_raw_callback', fake_raw)
+    monkeypatch.setattr(cubature_module, '_cython_cubature', fake_standard)
+
+    CBTYPE = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_void_p)
+
+    def c_func(x):
+        return 0.0
+
+    c_cb = CBTYPE(c_func)
+
+    cub(c_cb, ndim=1, fdim=1, xmin=[0], xmax=[1])
+
+    assert 'raw' in called and 'standard' not in called


### PR DESCRIPTION
## Summary
- add new test suite `tests/test_cubature_wrapper.py`
- validate input checks and raw callback dispatch in `cubature.cubature`

## Testing
- `pytest -q`
- `pytest --cov=./cubature --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c7c7ec988320983711f972c54115